### PR TITLE
Update project to bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.8.1"
+bevy = "0.11.0"
 bevy_hanabi = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,8 +311,8 @@ fn setup_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
             .with_style(
                 Style {
                     position_type: PositionType::Absolute,
-                    top: SCOREBOARD_TEXT_PADDING,
-                    left: SCREEN_WIDTH / 2.0,
+                    top: Val::Px(SCOREBOARD_TEXT_PADDING),
+                    left: Val::Px(SCREEN_WIDTH / 2.0),
                     ..default()
                 }),
         )
@@ -330,8 +330,8 @@ fn setup_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
             )])
             .with_style(Style {
                 position_type: PositionType::Absolute,
-                top: SCOREBOARD_TEXT_PADDING,
-                right: SCREEN_WIDTH / 2.0,
+                top: Val::Px(SCOREBOARD_TEXT_PADDING),
+                right: Val::Px(SCREEN_WIDTH / 2.0),
                 ..default()
             }),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use bevy::{
     prelude::*,
     sprite::collide_aabb::{collide, Collision},
-    sprite::MaterialMesh2dBundle, // TODO: Migrate sprites to this thing
+    //sprite::MaterialMesh2dBundle, // TODO: Migrate sprites to this thing
 };
 
 /* -- CONSTANTS -- */
@@ -98,13 +98,14 @@ struct CollisionSound(Handle<AudioSource>);
 fn main() {
     App::new()
         .insert_resource(ClearColor(BACKGROUND_COLOR))
-        .add_plugins(DefaultPlugins)
-        //.insert_resource(WindowDescriptor {
-        //    title: "Single Page PONG".to_string(),
-        //    width: SCREEN_WIDTH,
-        //    height: SCREEN_HEIGHT,
-        //    ..default()
-        //})
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "Unbeatable Pong".to_string(),
+                resolution: (SCREEN_WIDTH, SCREEN_HEIGHT).into(),
+                ..default()
+            }),
+            ..default()
+          }))
         .insert_resource(Scoreboard {
             left_score: 0,
             right_score: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,15 +308,13 @@ fn setup_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
                     color: WALL_COLOR,
                 },
             )])
-            .with_style(Style {
-                position_type: PositionType::Absolute,
-                //position: UiRect {
-                //    top: Val::Px(SCOREBOARD_TEXT_PADDING),
-                //    left: Val::Px(SCREEN_WIDTH / 2.0),
-                //    ..default()
-                //},
-                ..default()
-            }),
+            .with_style(
+                Style {
+                    position_type: PositionType::Absolute,
+                    top: SCOREBOARD_TEXT_PADDING,
+                    left: SCREEN_WIDTH / 2.0,
+                    ..default()
+                }),
         )
         .insert(Left);
 
@@ -332,11 +330,8 @@ fn setup_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
             )])
             .with_style(Style {
                 position_type: PositionType::Absolute,
-                //position: UiRect {
-                //    top: Val::Px(SCOREBOARD_TEXT_PADDING),
-                //    right: Val::Px(SCREEN_WIDTH / 2.0),
-                //    ..default()
-                //},
+                top: SCOREBOARD_TEXT_PADDING,
+                right: SCREEN_WIDTH / 2.0,
                 ..default()
             }),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,8 @@
 use bevy::{
     prelude::*,
     sprite::collide_aabb::{collide, Collision},
-    time::FixedTimestep,
+    sprite::MaterialMesh2dBundle, // TODO: Migrate sprites to this thing
 };
-
-use bevy_hanabi::prelude::*;
 
 /* -- CONSTANTS -- */
 // SCREEN
@@ -56,16 +54,16 @@ const SCOREBOARD_FONT_SIZE: f32 = 40.0;
 const SCOREBOARD_TEXT_PADDING: f32 = 5.0;
 
 // EVENTS
-#[derive(Default)]
+#[derive(Event, Default)]
 pub struct CollisionEvent;
 
-#[derive(Default)]
+#[derive(Event, Default)]
 pub struct LeftCollisionEvent {
     pub puck_position: Vec2,
     pub puck_direction: Vec2,
 }
 
-#[derive(Default)]
+#[derive(Event, Default)]
 pub struct GoalEvent {
     pub is_left_goal: bool,
 }
@@ -94,20 +92,19 @@ pub struct Ai {
 }
 
 // SOUNDS
-//#[derive(Resource)]
+#[derive(Resource)]
 struct CollisionSound(Handle<AudioSource>);
 
 fn main() {
     App::new()
         .insert_resource(ClearColor(BACKGROUND_COLOR))
         .add_plugins(DefaultPlugins)
-        .add_plugin(HanabiPlugin)
-        .insert_resource(WindowDescriptor {
-            title: "Single Page PONG".to_string(),
-            width: SCREEN_WIDTH,
-            height: SCREEN_HEIGHT,
-            ..default()
-        })
+        //.insert_resource(WindowDescriptor {
+        //    title: "Single Page PONG".to_string(),
+        //    width: SCREEN_WIDTH,
+        //    height: SCREEN_HEIGHT,
+        //    ..default()
+        //})
         .insert_resource(Scoreboard {
             left_score: 0,
             right_score: 0,
@@ -115,19 +112,19 @@ fn main() {
         .add_event::<CollisionEvent>()
         .add_event::<LeftCollisionEvent>()
         .add_event::<GoalEvent>()
-        .add_startup_system(setup)
-        .add_startup_system(setup_scoreboard)
-        .add_startup_system(setup_assets)
-        .add_system_set(
-            SystemSet::new()
-                .with_run_criteria(FixedTimestep::step(TIME_STEP as f64))
-                .with_system(move_left_paddle.before(check_collisions))
-                .with_system(ai_move_right_paddle.before(check_collisions))
-                .with_system(apply_velocity.before(check_collisions))
-                .with_system(check_collisions)
-                .with_system(on_goal_scored)
-                .with_system(play_collision_sound.after(check_collisions))
-                .with_system(set_ai_target),
+        .insert_resource(FixedTime::new_from_secs(TIME_STEP))
+        .add_systems(Startup, (setup, setup_scoreboard, setup_assets))
+        .add_systems(
+            FixedUpdate,
+            (
+                move_left_paddle.before(check_collisions),
+                ai_move_right_paddle.before(check_collisions),
+                apply_velocity.before(check_collisions),
+                check_collisions,
+                on_goal_scored,
+                play_collision_sound.after(check_collisions),
+                set_ai_target,
+            ),
         )
         .run();
 }
@@ -144,27 +141,27 @@ fn setup(mut commands: Commands) {
 }
 
 fn setup_camera(commands: &mut Commands) {
-    commands.spawn_bundle(Camera2dBundle::default());
+    commands.spawn(Camera2dBundle::default());
 }
 fn setup_walls(commands: &mut Commands) {
     commands
-        .spawn_bundle(RectBundle::new(LEFT_WALL_POS, LEFT_RIGHT_WALL_DIMS))
+        .spawn(RectBundle::new(LEFT_WALL_POS, LEFT_RIGHT_WALL_DIMS))
         .insert(Goal)
         .insert(Left);
     commands
-        .spawn_bundle(RectBundle::new(RIGHT_WALL_POS, LEFT_RIGHT_WALL_DIMS))
+        .spawn(RectBundle::new(RIGHT_WALL_POS, LEFT_RIGHT_WALL_DIMS))
         .insert(Goal);
-    commands.spawn_bundle(RectBundle::new(TOP_WALL_POS, TOP_BOTTOM_WALL_DIMS));
-    commands.spawn_bundle(RectBundle::new(BOTTOM_WALL_POS, TOP_BOTTOM_WALL_DIMS));
+    commands.spawn(RectBundle::new(TOP_WALL_POS, TOP_BOTTOM_WALL_DIMS));
+    commands.spawn(RectBundle::new(BOTTOM_WALL_POS, TOP_BOTTOM_WALL_DIMS));
 }
 
 fn setup_paddles(commands: &mut Commands) {
     commands
-        .spawn_bundle(RectBundle::new(LEFT_PADDLE_POS, PADDLE_DIMS))
+        .spawn(RectBundle::new(LEFT_PADDLE_POS, PADDLE_DIMS))
         .insert(Paddle)
         .insert(Left);
     commands
-        .spawn_bundle(RectBundle::new(RIGHT_PADDLE_POS, PADDLE_DIMS))
+        .spawn(RectBundle::new(RIGHT_PADDLE_POS, PADDLE_DIMS))
         .insert(Paddle)
         .insert(Right)
         .insert(Ai { y_target: 0.0 });
@@ -172,7 +169,7 @@ fn setup_paddles(commands: &mut Commands) {
 
 fn setup_puck(commands: &mut Commands) {
     commands
-        .spawn_bundle(RectBundle::new(PUCK_SPAWN_POS, PUCK_DIMS))
+        .spawn(RectBundle::new(PUCK_SPAWN_POS, PUCK_DIMS))
         .insert(Velocity(INITIAL_PUCK_DIRECTION.normalize() * PUCK_SPEED));
 }
 
@@ -180,7 +177,7 @@ fn setup_dotted_line(commands: &mut Commands) {
     let increment: f32 = SCREEN_HEIGHT / (NUM_DOTTED_LINES as f32);
     let bottom: f32 = -SCREEN_HEIGHT / 2.0 + LINE_DIMS.y + WALL_THICKNESS;
     for y_index in 0..NUM_DOTTED_LINES {
-        commands.spawn_bundle(sprite_bundle_from_pos_size(
+        commands.spawn(sprite_bundle_from_pos_size(
             Vec2::new(0.0, y_index as f32 * increment + bottom),
             LINE_DIMS,
         ));
@@ -301,8 +298,9 @@ fn ai_move_right_paddle(
 
 fn setup_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
-        .spawn_bundle(
-            TextBundle::from_sections([TextSection::new(
+        .spawn(
+            TextBundle::from_sections([
+                TextSection::new(
                 "0",
                 TextStyle {
                     font: asset_server.load("fonts/Arame-Bold.ttf"),
@@ -312,18 +310,18 @@ fn setup_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
             )])
             .with_style(Style {
                 position_type: PositionType::Absolute,
-                position: UiRect {
-                    top: Val::Px(SCOREBOARD_TEXT_PADDING),
-                    left: Val::Px(SCREEN_WIDTH / 2.0),
-                    ..default()
-                },
+                //position: UiRect {
+                //    top: Val::Px(SCOREBOARD_TEXT_PADDING),
+                //    left: Val::Px(SCREEN_WIDTH / 2.0),
+                //    ..default()
+                //},
                 ..default()
             }),
         )
         .insert(Left);
 
     commands
-        .spawn_bundle(
+        .spawn(
             TextBundle::from_sections([TextSection::new(
                 "0",
                 TextStyle {
@@ -334,11 +332,11 @@ fn setup_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
             )])
             .with_style(Style {
                 position_type: PositionType::Absolute,
-                position: UiRect {
-                    top: Val::Px(SCOREBOARD_TEXT_PADDING),
-                    right: Val::Px(SCREEN_WIDTH / 2.0),
-                    ..default()
-                },
+                //position: UiRect {
+                //    top: Val::Px(SCOREBOARD_TEXT_PADDING),
+                //    right: Val::Px(SCREEN_WIDTH / 2.0),
+                //    ..default()
+                //},
                 ..default()
             }),
         )
@@ -429,20 +427,27 @@ fn check_collisions(
 }
 
 fn play_collision_sound(
-    collision_events: EventReader<CollisionEvent>,
-    audio: Res<Audio>,
+    mut commands: Commands,
+    mut collision_events: EventReader<CollisionEvent>,
+    //audio: Res<Audio>,
     sound: Res<CollisionSound>,
 ) {
     // Play a sound once per frame if a collision occurred.
     if !collision_events.is_empty() {
         // This prevents events staying active on the next frame.
         collision_events.clear();
-        audio.play(sound.0.clone());
+        commands.spawn(AudioBundle {
+            source: sound.0.clone(),
+            // auto-despawn the entity when playback finishes
+            settings: PlaybackSettings::DESPAWN,
+        });
+        //audio.play(sound.0.clone());
     }
 }
 
 // BUNDLES and Resources
 
+#[derive(Resource)]
 struct Scoreboard {
     left_score: usize,
     right_score: usize,
@@ -450,7 +455,7 @@ struct Scoreboard {
 
 #[derive(Bundle)]
 struct RectBundle {
-    #[bundle]
+    //#[bundle]
     sprite_bundle: SpriteBundle,
     collider: Collider,
 }


### PR DESCRIPTION
Had some free time on paternity leave to update this old project to the latest version of bevy.

Since 0.9 there have been changes with how systems are setup:
```
        .add_systems(Startup, (setup, setup_scoreboard, setup_assets))
        .add_systems(
            FixedUpdate,
            (
                move_left_paddle.before(check_collisions),
                ai_move_right_paddle.before(check_collisions),
                apply_velocity.before(check_collisions),
                check_collisions,
                on_goal_scored,
                play_collision_sound.after(check_collisions),
                set_ai_target,
            ),
```
The way for setting up window descriptors has changed twice:
```
        .add_plugins(DefaultPlugins.set(WindowPlugin {
            primary_window: Some(Window {
                title: "Unbeatable Pong".to_string(),
                resolution: (SCREEN_WIDTH, SCREEN_HEIGHT).into(),
                ..default()
            }),
            ..default()
          }))
```
And `spawn_bundle` has been replaced with simply `spawn`